### PR TITLE
feature/#5-self-auth-2

### DIFF
--- a/src/modules/members/members.controller.ts
+++ b/src/modules/members/members.controller.ts
@@ -6,13 +6,17 @@ import {
   Patch,
   Param,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { MembersService } from './members.service';
 import { CreateMemberDto } from './dto/create-member.dto';
 import { UpdateMemberDto } from './dto/update-member.dto';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AuthAdminGuard } from '../auth/auth.guard';
 
 @ApiTags('멤버 API')
+@UseGuards(AuthAdminGuard)
+@ApiBearerAuth()
 @Controller('members')
 export class MembersController {
   constructor(private readonly membersService: MembersService) {}

--- a/src/modules/members/members.service.spec.ts
+++ b/src/modules/members/members.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { MembersService } from './members.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { Member, MemberStatus, Role } from '@prisma/client';
+import { SignUpDto } from '../auth/dto/sign-up.dto';
 
 describe('MembersService', () => {
   let service: MembersService;
@@ -55,7 +56,15 @@ describe('MembersService', () => {
   });
 
   it('should create a member', async () => {
-    expect(await service.create(member)).toEqual(member);
+    const dto: SignUpDto = {
+      email: 'test@test.com',
+      nickname: 'test',
+      password: 'password',
+      passwordConfirm: 'password',
+      birthdate: new Date(),
+    };
+
+    expect(await service.create(dto)).toEqual(member);
   });
 
   it('should update a member', async () => {

--- a/src/modules/members/members.service.ts
+++ b/src/modules/members/members.service.ts
@@ -1,5 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { ConflictException, Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { CreateMemberDto } from './dto/create-member.dto';
+import ErrorMessage from '../../shared/constants/error-messages.constants';
 
 @Injectable()
 export class MembersService {
@@ -15,9 +17,9 @@ export class MembersService {
     });
   }
 
-  async create(data: any) {
+  async create(createMemberDto: CreateMemberDto) {
     return this.prismaService.member.create({
-      data,
+      data: createMemberDto,
     });
   }
 
@@ -32,5 +34,33 @@ export class MembersService {
     return this.prismaService.member.delete({
       where: { id },
     });
+  }
+
+  async findMemberByEmail(email: string) {
+    return this.prismaService.member.findUnique({
+      where: { email },
+    });
+  }
+
+  async findMemberByNickname(nickname: string) {
+    return this.prismaService.member.findUnique({
+      where: { nickname },
+    });
+  }
+
+  async checkValidEmail(email: string) {
+    const member = await this.findMemberByEmail(email);
+    if (member) {
+      throw new ConflictException(ErrorMessage.EMAIL_EXISTS);
+    }
+    return true;
+  }
+
+  async checkValidNickname(nickname: string) {
+    const member = await this.findMemberByNickname(nickname);
+    if (member) {
+      throw new ConflictException(ErrorMessage.NICKNAME_EXISTS);
+    }
+    return true;
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #5

## 📝작업 내용

저번 PR 에 빠뜨린 MemberService에 대한 수정 내역 반영
- member를 생성하는 create메서드에 DTO를 주입시킴
- AuthGuard로 일반 사용자가 접근할 수 없도록 수정
- ErrorMessage를 이용하여 일관성있는 에러 메시지를 출력

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
