### PR TITLE
feature/#40-docker-api-ready

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:13
+    restart: always
+    environment:
+      POSTGRES_USER: ${DATABASE_USERNAME}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+      POSTGRES_DB: ${DATABASE_NAME}
+      TZ: Asia/Seoul
+    volumes:
+      - ./data:/var/lib/postgresql/data
+    ports:
+      - ${DATABASE_PORT}:5432
+  pgadmin:
+    image: dpage/pgadmin4
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: l.juhyeonni@gmail.com
+      PGADMIN_DEFAULT_PASSWORD: 123qwe
+    volumes:
+      - ./pgadmin4:/var/lib/pgadmin
+    ports:
+      - 5050:80
+    depends_on:
+      - db
+  redis:
+    image: redis:6.2.5
+    restart: always
+    ports:
+      - 6379:6379
+    command: redis-server /usr/local/conf/redis.conf
+    volumes:
+      - ./redis/redis.conf:/usr/local/conf/redis.conf
+      - ./redis/data:/data


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #41 

## 📝작업 내용

기존 docker-copmose를 다 대체하려고 했으나, 
`node_modules`의 실시간성과 호환성을 위해 기존 `docker-compose.yaml`파일을 복구추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
