### PR TITLE
fix(eslint): eslint 규칙 수정 (no-unused-vars)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': 'warn',
   },
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

eslint deprecated된 설정을 고치고, 발견한 에러항목인
`no-unused-vars`의 에러 설정을 `warn`으로 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

자신의 `eslint`가 제대로 작동하고 있는지 확인해주세요. 예전 버전의 설정파일 경로가 잘못 지정되어 있을 수도 있습니다.