### PR TITLE
chore/alter-guide-profile-ref

### DIFF
--- a/prisma/migrations/20240223154157_alter_guide_review_id_reference_member_id/migration.sql
+++ b/prisma/migrations/20240223154157_alter_guide_review_id_reference_member_id/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `memberId` on the `GuideProfile` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "GuideProfile" DROP CONSTRAINT "GuideProfile_memberId_fkey";
+
+-- DropIndex
+DROP INDEX "GuideProfile_memberId_key";
+
+-- AlterTable
+ALTER TABLE "GuideProfile" DROP COLUMN "memberId",
+ALTER COLUMN "id" DROP DEFAULT;
+DROP SEQUENCE "guideprofile_id_seq";
+
+-- AddForeignKey
+ALTER TABLE "GuideProfile" ADD CONSTRAINT "GuideProfile_id_fkey" FOREIGN KEY ("id") REFERENCES "Member"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20240224061819_alter_guide_profile_rename_temperatrue_to_temperature/migration.sql
+++ b/prisma/migrations/20240224061819_alter_guide_profile_rename_temperatrue_to_temperature/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `temperatrue` on the `GuideProfile` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "GuideProfile" DROP COLUMN "temperatrue",
+ADD COLUMN     "temperature" DOUBLE PRECISION DEFAULT 36.5;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,8 +37,8 @@ model Member {
 }
 
 model GuideProfile {
-  id                  Int         @id @default(autoincrement())
-  temperatrue         Float?      @default(36.5)
+  id                  Int         @id
+  temperature         Float?      @default(36.5)
   service             String?
   areas               GuideArea[]
   phoneNumber         String?     @unique
@@ -46,8 +46,7 @@ model GuideProfile {
   verifiedID          Boolean?    @default(false)
   verifiedBankAccount Boolean?    @default(false)
 
-  memberId               Int                          @unique
-  member                 Member                       @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  member                 Member                       @relation(fields: [id], references: [id], onDelete: Cascade)
   languageCertifications GuideLanguageCertification[]
   reviews                GuideReview[]
 }

--- a/src/modules/guides/guides.repository.ts
+++ b/src/modules/guides/guides.repository.ts
@@ -62,7 +62,7 @@ export class GuidesRepository {
         guideProfile: {
           upsert: {
             where: {
-              memberId: id,
+              id,
             },
             create: {},
             update: {},
@@ -84,7 +84,7 @@ export class GuidesRepository {
   async updateAreas(id: number, areaIds: number[]) {
     const currentAreaIds = await this.prismaService.guideArea
       .findMany({
-        where: { guide: { memberId: id } },
+        where: { guide: { id } },
         select: {
           areaId: true,
         },
@@ -102,7 +102,7 @@ export class GuidesRepository {
     }
 
     return this.prismaService.guideProfile.update({
-      where: { memberId: id },
+      where: { id },
       data: {
         areas: {
           deleteMany: {
@@ -129,7 +129,7 @@ export class GuidesRepository {
       await this.prismaService.guideLanguageCertification
         .findMany({
           where: {
-            guide: { memberId: id },
+            guide: { id },
           },
           select: {
             languageCertificationId: true,
@@ -154,7 +154,7 @@ export class GuidesRepository {
     }
 
     return this.prismaService.guideProfile.update({
-      where: { memberId: id },
+      where: { id },
       data: {
         languageCertifications: {
           deleteMany: {
@@ -179,7 +179,7 @@ export class GuidesRepository {
   async leaveGuide(id: number) {
     return this.prismaService.$transaction([
       this.prismaService.guideProfile.delete({
-        where: { memberId: id },
+        where: { id },
       }),
       this.prismaService.member.update({
         where: { id },
@@ -196,7 +196,7 @@ export class GuidesRepository {
 
   async registerPhoneNumber(id: number, phoneNumber: string) {
     return this.prismaService.guideProfile.update({
-      where: { memberId: id },
+      where: { id },
       data: { phoneNumber },
     });
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

guide 스키마를 컬럼을 삭제 및 통합, 오타 수정했습니다.
- GuideProfile 스키마의 `temperatrue` -> `temperature` 오타 수정
- GuideProfile 스키마의 memberId를 삭제 후, Member의 `id`와 GuideProfile의 `id`를 참조함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

