### PR TITLE
refactor/split-authorization

### DIFF
--- a/src/modules/auth/auth.decorator.ts
+++ b/src/modules/auth/auth.decorator.ts
@@ -1,0 +1,9 @@
+import { ExecutionContext, createParamDecorator } from '@nestjs/common';
+import { Member } from '@prisma/client';
+
+export const User = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): Member => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/src/modules/auth/auth.jwt-refresh.strategy.ts
+++ b/src/modules/auth/auth.jwt-refresh.strategy.ts
@@ -4,7 +4,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
-import { Strategy } from 'passport-jwt';
+import { ExtractJwt, Strategy } from 'passport-jwt';
 import { Request } from 'express';
 import { AuthPayload } from 'src/interfaces/auth.interface';
 import { MembersService } from '../members/members.service';
@@ -25,7 +25,11 @@ export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'refresh') {
     private readonly jwtService: JwtService,
   ) {
     super({
-      jwtFromRequest: cookieExtractor,
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        ExtractJwt.fromAuthHeaderAsBearerToken(),
+        ExtractJwt.fromUrlQueryParameter('token'),
+        cookieExtractor,
+      ]),
       ignoreExpiration: process.env.NODE_ENV !== 'production',
       secretOrKey: configService.get<string>('JWT_SECRET'),
     });

--- a/src/modules/auth/auth.jwt.strategy.ts
+++ b/src/modules/auth/auth.jwt.strategy.ts
@@ -10,7 +10,6 @@ import { AuthPayload } from '../../interfaces/auth.interface';
 import { MembersService } from '../members/members.service';
 import ErrorMessage from '../../shared/constants/error-messages.constants';
 import { ConfigService } from '@nestjs/config';
-import { MemberStatus } from '@prisma/client';
 
 const cookieExtractor = (req: Request) => {
   return req.cookies.accessToken;
@@ -38,13 +37,6 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
 
     if (!member) {
       throw new UnauthorizedException(ErrorMessage.UNAUTHORIZED);
-    }
-
-    if (
-      member.status === MemberStatus.DELETED ||
-      member.status === MemberStatus.INACTIVE
-    ) {
-      throw new ForbiddenException(ErrorMessage.FORBIDDEN_MEMBER);
     }
 
     return member;

--- a/src/modules/guides/guides.controller.ts
+++ b/src/modules/guides/guides.controller.ts
@@ -38,6 +38,7 @@ import {
 import { ParseGenderPipe } from './guides.pipe';
 import { GuidePagination } from './guides.decorator';
 import { UpdateServiceDto } from './dto/update-service.dto';
+import { User } from '../auth/auth.decorator';
 
 @ApiTags('가이드 API')
 @Controller('guides')
@@ -110,11 +111,11 @@ export class GuidesController {
     description: '가이드로 등록합니다.',
   })
   async registerGuide(
-    @Req() req: { user: Member },
+    @User() user: Member,
     @Body() registerGuideDto: RegisterGuideDto,
     @Res() res: Response,
   ) {
-    const { id } = req.user;
+    const { id } = user;
     await this.guidesService.registerGuide(+id, registerGuideDto);
 
     return res.json({ message: '가이드 등록이 완료되었습니다.' });
@@ -127,11 +128,11 @@ export class GuidesController {
     description: '가이드의 활동지역 정보를 수정합니다.',
   })
   async updateAreas(
-    @Req() req: { user: Member },
+    @User() user: Member,
     @Body() { areaIds }: UpdateAreasDto,
     @Res() res: Response,
   ) {
-    const { id } = req.user;
+    const { id } = user;
     await this.guidesService.updateAreas(id, areaIds);
 
     return res.json({ message: '가이드 활동지역 정보가 수정되었습니다.' });
@@ -144,11 +145,11 @@ export class GuidesController {
     description: '가이드의 언어 정보를 수정합니다.',
   })
   async updateLanguage(
-    @Req() req: { user: Member },
+    @User() user: Member,
     @Body() { languageIds }: UpdateLanguagesDto,
     @Res() res: Response,
   ) {
-    const { id } = req.user;
+    const { id } = user;
     await this.guidesService.updateLanguageCertifications(id, languageIds);
 
     return res.json({ message: '가이드 언어 정보가 수정되었습니다.' });
@@ -161,11 +162,11 @@ export class GuidesController {
     description: '가이드의 언어 자격증 정보를 수정합니다.',
   })
   async updateLanguageCertifications(
-    @Req() req: { user: Member },
+    @User() user: Member,
     @Body() { languageCertificationIds }: UpdateLanguageCertificationsDto,
     @Res() res: Response,
   ) {
-    const { id } = req.user;
+    const { id } = user;
     await this.guidesService.updateLanguageCertifications(
       id,
       languageCertificationIds,
@@ -181,11 +182,11 @@ export class GuidesController {
     description: '가이드의 서비스 정보를 수정합니다.',
   })
   async updateService(
-    @Req() req: { user: Member },
+    @User() user: Member,
     @Body() { content }: UpdateServiceDto,
     @Res() res: Response,
   ) {
-    const { id } = req.user;
+    const { id } = user;
     await this.guidesService.updateService(id, content);
 
     return res.json({ message: '가이드 서비스 정보가 수정되었습니다.' });
@@ -197,8 +198,8 @@ export class GuidesController {
     summary: '가이드 탈퇴',
     description: '가이드를 탈퇴합니다. 유저로 전환됩니다.',
   })
-  async leaveGuide(@Req() req: { user: Member }, @Res() res: Response) {
-    const { id } = req.user;
+  async leaveGuide(@User() user: Member, @Res() res: Response) {
+    const { id } = user;
     await this.guidesService.leaveGuide(id);
 
     return res.json({ message: '가이드 탈퇴가 완료되었습니다.' });
@@ -211,11 +212,11 @@ export class GuidesController {
     description: '가이드의 휴대폰 번호를 등록합니다.',
   })
   async registerPhoneNumber(
-    @Req() req: { user: Member },
+    @User() user: Member,
     @Body() registerPhoneNumberDto: RegisterPhoneNumberDto,
     @Res() res: Response,
   ) {
-    const { id } = req.user;
+    const { id } = user;
     const { phoneNumber, authCode } = registerPhoneNumberDto;
     await this.guidesService.registerPhoneNumber(id, phoneNumber, authCode);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

`유저`, `멤버`, `관리자` 등 인가 관련된 로직의 담당 분리

strategy에서 role에 대한 인가를 적용하지 않고, guard에서 적용하기로 함.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
