### PR TITLE
refactor(guide_pagination): 가이드 페이지네이션 조회 구조 변경, 점수가 정상적으로 조회안되었던 것 수정

### DIFF
--- a/src/modules/guides/guides.interface.ts
+++ b/src/modules/guides/guides.interface.ts
@@ -30,28 +30,3 @@ export interface GuideWithMatchingAvgScore {
   avgLocationScore: number;
   totalAvgScore: number;
 }
-
-export interface GuidePaginatedData
-  extends Pick<Member, 'id' | 'nickname' | 'avatar' | 'birthdate'> {
-  languages: {
-    language: {
-      id: number;
-      name: string;
-    };
-  }[];
-  guideProfile: {
-    areas: {
-      area: {
-        id: number;
-        name: string;
-      };
-      temperature?: number;
-    }[];
-  };
-  tags: {
-    tag: {
-      id: number;
-      name: string;
-    };
-  }[];
-}

--- a/src/modules/guides/guides.repository.ts
+++ b/src/modules/guides/guides.repository.ts
@@ -160,7 +160,11 @@ export class GuidesRepository {
       temperature,
     } = options;
 
-    const whereCondition: Prisma.GuideProfileWhereInput = {};
+    const whereCondition: Prisma.GuideProfileWhereInput = {
+      member: {
+        role: Role.GUIDE,
+      },
+    };
 
     if (cursor) {
       whereCondition.id = { lt: cursor };

--- a/src/modules/guides/guides.repository.ts
+++ b/src/modules/guides/guides.repository.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { Prisma, Role } from '@prisma/client';
+import { GuideProfile, Prisma, Role } from '@prisma/client';
 import { RegisterGuideDto } from './dto/register-guide.dto';
 import { MembersRepository } from '../members/members.repository';
 import {
-  GuidePaginatedData,
   GuidePaginationOptions,
   GuideWithMatchingAvgScore,
 } from './guides.interface';
@@ -45,54 +44,58 @@ export class GuidesRepository {
     const whereCondition = this.buildWhereCondition(cursor, options);
     const orderBy = this.buildOrderBy(options);
 
-    const guidesWithMatchingAvgScores =
-      await this.getGuidesWithMatchingAvgScores(
-        options?.score ?? [0, 1, 2, 3, 4, 5],
-      );
+    const guideAvgScores = await this.getGuidesWithMatchingAvgScores(
+      options.score || [0, 1, 2, 3, 4, 5],
+    );
+    console.log('🚀 ~ GuidesRepository ~ guideAvgScores:', guideAvgScores);
 
-    const guides: GuidePaginatedData[] =
-      await this.prismaService.member.findMany({
+    const guides: GuideProfile[] =
+      await this.prismaService.guideProfile.findMany({
         where: whereCondition,
         take: limit,
         orderBy: orderBy,
-        select: {
-          id: true,
-          nickname: true,
-          avatar: true,
-          birthdate: true,
-          languages: {
-            select: {
-              language: true,
-            },
-          },
-          guideProfile: {
-            select: {
-              areas: {
+        include: {
+          member: {
+            include: {
+              languages: {
                 select: {
-                  area: true,
+                  language: true,
                 },
               },
-              temperature: true,
+              tags: {
+                select: {
+                  tag: true,
+                },
+              },
             },
           },
-          guideReviews: {},
-          tags: {
+          areas: {
             select: {
-              tag: true,
+              area: true,
+            },
+          },
+          languageCertifications: {
+            select: {
+              languageCertification: true,
+            },
+          },
+          _count: {
+            select: {
+              reviews: true,
             },
           },
         },
       });
 
     const result = this.enrichGuides(guides, {
-      guidesWithMatchingAvgScores,
+      guidesWithMatchingAvgScores: guideAvgScores,
     });
 
     return result;
   }
 
   private enrichGuides(
-    guides: GuidePaginatedData[],
+    guides: GuideProfile[],
     additional: {
       guidesWithMatchingAvgScores?: GuideWithMatchingAvgScore[];
     },
@@ -100,19 +103,23 @@ export class GuidesRepository {
     const { guidesWithMatchingAvgScores } = additional;
 
     if (guidesWithMatchingAvgScores) {
-      return guides.map((guide) => {
-        const matching = guidesWithMatchingAvgScores.find(
-          (item) => item.guideId === guide.id,
-        );
+      return guides
+        .filter((guide) =>
+          guidesWithMatchingAvgScores.some((item) => item.guideId === guide.id),
+        )
+        .map((guide) => {
+          const matching = guidesWithMatchingAvgScores.find(
+            (item) => item.guideId === guide.id,
+          );
 
-        return {
-          ...guide,
-          avgLocationScore: +matching?.avgLocationScore || 0,
-          avgKindnessScore: +matching?.avgKindnessScore || 0,
-          avgCommunicationScore: +matching?.avgCommunicationScore || 0,
-          totalAvgScore: +matching?.totalAvgScore || 0,
-        };
-      });
+          return {
+            ...guide,
+            avgLocationScore: +matching?.avgLocationScore || 0,
+            avgKindnessScore: +matching?.avgKindnessScore || 0,
+            avgCommunicationScore: +matching?.avgCommunicationScore || 0,
+            totalAvgScore: +matching?.totalAvgScore || 0,
+          };
+        });
     }
   }
 
@@ -122,24 +129,26 @@ export class GuidesRepository {
   }: Pick<
     GuidePaginationOptions,
     'orderBy' | 'sort'
-  >): Prisma.MemberOrderByWithRelationInput {
+  >): Prisma.GuideProfileOrderByWithRelationInput {
     if (!orderBy) {
       return { id: 'desc' };
     }
 
     if (orderBy === 'guideCount') {
-      return { guideReviews: { _count: sort } };
+      return {
+        reviews: { _count: sort },
+      };
     }
 
     if (orderBy === 'temperature') {
-      return { guideProfile: { temperature: sort } };
+      return { temperature: sort };
     }
   }
 
   private buildWhereCondition(
     cursor?: number,
     options?: GuidePaginationOptions,
-  ): Prisma.MemberWhereInput {
+  ): Prisma.GuideProfileWhereInput {
     const {
       areas,
       age,
@@ -151,16 +160,14 @@ export class GuidesRepository {
       temperature,
     } = options;
 
-    const whereCondition: Prisma.MemberWhereInput = {
-      role: Role.GUIDE,
-    };
+    const whereCondition: Prisma.GuideProfileWhereInput = {};
 
     if (cursor) {
       whereCondition.id = { lt: cursor };
     }
 
     if (gender) {
-      whereCondition.gender = options.gender;
+      whereCondition.member.gender = options.gender;
     }
 
     if (age) {
@@ -168,36 +175,29 @@ export class GuidesRepository {
         age.min,
         age.max,
       );
-      whereCondition.birthdate = {
+      whereCondition.member.birthdate = {
         gte: start,
         lte: end,
       };
     }
 
-    // TODO:
-    // guideCount
-
     if (temperature) {
-      whereCondition.guideProfile = {
-        temperature: {
-          gte: temperature.min,
-          lte: temperature.max,
-        },
+      whereCondition.temperature = {
+        gte: temperature.min,
+        lte: temperature.max,
       };
     }
 
     if (areas) {
-      whereCondition.guideProfile = {
-        areas: {
-          some: {
-            areaId: { in: areas },
-          },
+      whereCondition.areas = {
+        some: {
+          areaId: { in: areas },
         },
       };
     }
 
     if (languages) {
-      whereCondition.languages = {
+      whereCondition.member.languages = {
         some: {
           languageId: { in: languages },
         },
@@ -205,11 +205,9 @@ export class GuidesRepository {
     }
 
     if (languageCertifications) {
-      whereCondition.guideProfile = {
-        languageCertifications: {
-          some: {
-            languageCertificationId: { in: languageCertifications },
-          },
+      whereCondition.languageCertifications = {
+        some: {
+          languageCertificationId: { in: languageCertifications },
         },
       };
     }
@@ -226,7 +224,7 @@ export class GuidesRepository {
         AVG("communicationScore") AS "avgCommunicationScore",
         AVG("kindnessScore") AS "avgKindnessScore",
         AVG("locationScore") AS "avgLocationScore",
-        ROUND((AVG("communicationScore") + AVG("kindnessScore") + AVG("locationScore")) / 3) AS "totalAvgScore"
+        ROUND((AVG("communicationScore") + AVG("kindnessScore") + AVG("locationScore")) / 3, 1) AS "totalAvgScore"
       FROM
         Public."GuideReview"
       GROUP BY
@@ -243,11 +241,32 @@ export class GuidesRepository {
   async findOne(id: number) {
     return this.prismaService.member.findUnique({
       where: { id, role: Role.GUIDE },
-      select: {
-        avatar: true,
-        birthdate: true,
-        boardLikes: true,
-        guideProfile: true,
+      include: {
+        guideProfile: {
+          include: {
+            areas: {
+              select: {
+                area: true,
+              },
+            },
+            languageCertifications: {
+              select: {
+                languageCertification: {
+                  select: {
+                    id: true,
+                    name: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+        languages: {
+          select: {
+            language: true,
+          },
+        },
+        tags: { include: { tag: { select: { id: true, name: true } } } },
       },
     });
   }
@@ -384,7 +403,6 @@ export class GuidesRepository {
       data: { service: content },
     });
   }
-
 
   /**
    * 가이드에서 탈퇴하고, 멤버의 역할을 USER로 업데이트합니다.

--- a/src/modules/guides/guides.repository.ts
+++ b/src/modules/guides/guides.repository.ts
@@ -225,9 +225,9 @@ export class GuidesRepository {
     return this.prismaService.$queryRaw`
       SELECT
         "guideId",
-        AVG("communicationScore") AS "avgCommunicationScore",
-        AVG("kindnessScore") AS "avgKindnessScore",
-        AVG("locationScore") AS "avgLocationScore",
+        ROUND(AVG("communicationScore"), 1) AS "avgCommunicationScore",
+        ROUND(AVG("kindnessScore"), 1) AS "avgKindnessScore",
+        ROUND(AVG("locationScore"), 1) AS "avgLocationScore",
         ROUND((AVG("communicationScore") + AVG("kindnessScore") + AVG("locationScore")) / 3, 1) AS "totalAvgScore"
       FROM
         Public."GuideReview"


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #43 

## 📝작업 내용

- 가이드 페이지네이션 조회 구조 변경
- 정렬기준 temperature 추가
- 점수에 해당하는 가이드 호출 에러 수정
- 안쓰이는 `GuidePaginatedData` interface 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


