### PR TITLE
fix(guide_pagination): 점수 필터링 로직 수정

### DIFF
--- a/src/shared/pagination/dto/page-response.dto.ts
+++ b/src/shared/pagination/dto/page-response.dto.ts
@@ -1,4 +1,4 @@
 export interface PageResponse<T> {
   items: T[]; // 현재 페이지의 아이템
-  nextCursor?: string; // 다음 페이지를 위한 cursor
+  nextCursor?: number; // 다음 페이지를 위한 cursor
 }

--- a/src/shared/pagination/pagination.utils.ts
+++ b/src/shared/pagination/pagination.utils.ts
@@ -10,9 +10,9 @@ export function createPageResponse<T extends ItemWithId>(
   pageRequest: PageRequest,
   totalItems: number,
 ): PageResponse<T> {
-  let nextCursor = null;
+  let nextCursor = pageRequest.cursor ?? null;
 
-  if (items.length > 0) {
+  if (totalItems > 0) {
     const lastItem = items[items.length - 1];
     nextCursor = lastItem.id;
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #109 

## 📝작업 내용

가이드 페이지네이션에서 점수 필터링이 정상작동이 안된 로직을 수정했습니다. 수정계획은 #109 에서 확인할 수 있습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


